### PR TITLE
Support pre debugger discovery operations

### DIFF
--- a/Examples/ScriptLibrary/LibraryBase.cs
+++ b/Examples/ScriptLibrary/LibraryBase.cs
@@ -226,6 +226,8 @@ To send or receive events to/from a specific group from outside that group appen
 
         public sealed override void Init()
         {
+            PreSimpleInit();
+
             __SimpleTag = GetType().Name + " [S:" + Script.ID.ToString() + " O:" + ObjectPrivate.ObjectId.ToString() + "]";
             StartCoroutine(FindDebugger, 0.1);
             Yield();
@@ -235,6 +237,8 @@ To send or receive events to/from a specific group from outside that group appen
 
             SimpleInit();
         }
+
+        virtual protected void PreSimpleInit() {}
 
         private void FindDebugger(double rate)
         {

--- a/Examples/ScriptLibrary/LibraryBase.cs
+++ b/Examples/ScriptLibrary/LibraryBase.cs
@@ -226,10 +226,11 @@ To send or receive events to/from a specific group from outside that group appen
 
         public sealed override void Init()
         {
-            PreSimpleInit();
-
             __SimpleTag = GetType().Name + " [S:" + Script.ID.ToString() + " O:" + ObjectPrivate.ObjectId.ToString() + "]";
             StartCoroutine(FindDebugger, 0.1);
+
+            PreSimpleInit();
+            
             Yield();
 
             int retries = 15;


### PR DESCRIPTION
Since every simple script has a delay before `SimpleInit()` is called, would be nice if we could do operations before the debugger was discovered, such as register reflectives.